### PR TITLE
Update secp256k1 to use bitcoin-core directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ vcpkg \
 
 Fix the formatting of all `port` manifests.
 
-> NOTE: This script is written for fish shell only
-
 ```sh
 # NOTE: This script is written for fish shell only
 for f in /data/shared/code/wire/wire-vcpkg-registry/ports/*/vcpkg.json
@@ -56,3 +54,10 @@ for f in /data/shared/code/wire/wire-vcpkg-registry/ports/*/vcpkg.json
 end
 ```
 
+```sh
+# NOTE: This script is written for bash or zsh
+for f in ports/*/vcpkg.json; do
+    echo "vcpkg: $f"
+    vcpkg format-manifest $f
+done
+```

--- a/ports/bls12-381/portfile.cmake
+++ b/ports/bls12-381/portfile.cmake
@@ -4,7 +4,6 @@ vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL https://github.com/AntelopeIO/bls12-381.git
   REF 6b718d127a2b6095593a85622b4e3f85c3fbbcf6
-  SHA512 6b718d127a2b6095593a85622b4e3f85c3fbbcf6
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/bn256/portfile.cmake
+++ b/ports/bn256/portfile.cmake
@@ -4,7 +4,6 @@ vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL https://github.com/Wire-Network/bn256.git
   REF 34c90583fba83f3dc385eab3415e61754aa309fc
-  SHA512 34c90583fba83f3dc385eab3415e61754aa309fc
 )
 
 file(COPY_FILE "${CMAKE_CURRENT_LIST_DIR}/bn256-CMakeLists.txt.cmake" "${SOURCE_PATH}/CMakeLists.txt")

--- a/ports/libsodium/portfile.cmake
+++ b/ports/libsodium/portfile.cmake
@@ -8,7 +8,6 @@ vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://github.com/Wire-Network/libsodium.git
     REF abd3612f433b795a6ac31a386a75f8f26a479033
-    SHA512 abd3612f433b795a6ac31a386a75f8f26a479033
     HEAD_REF master
     # PATCHES
     #     001-mingw-i386.patch

--- a/ports/secp256k1-internal/portfile.cmake
+++ b/ports/secp256k1-internal/portfile.cmake
@@ -2,9 +2,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
-  URL https://github.com/Wire-Network/secp256k1.git
-  REF 199d27cea32203b224b208627533c2e813cd3b21
-  SHA512 199d27cea32203b224b208627533c2e813cd3b21
+  URL https://github.com/bitcoin-core/secp256k1.git
+  REF a660a4976efe880bae7982ee410b9e0dc59ac983
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
@@ -17,7 +16,5 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "share/${PORT}" PACKAGE_NAME ${PORT})
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/secp256k1-internal/vcpkg.json
+++ b/ports/secp256k1-internal/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "secp256k1-internal",
-  "version": "1.0.0",
-  "description": "Optimized C library for EC operations on curve, customized for Wire",
-  "homepage": "https://github.com/wire-network/secp256k1",
+  "version": "0.7.0",
+  "description": "Optimized C library for EC operations on curve",
+  "homepage": "https://github.com/bitcoin-core/secp256k1",
   "license": "MIT",
   "dependencies": [
     {

--- a/versions/b-/bls12-381.json
+++ b/versions/b-/bls12-381.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "856a63823f3963d76f8af61d839c15e1f4bbe8a9",
+      "git-tree": "92dd66ce9030ef831b0eebfc20fb7e85c8b015a8",
       "version": "1.0.0-wire",
       "port-version": 0
     }

--- a/versions/b-/bn256.json
+++ b/versions/b-/bn256.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3e8f2336a11856e42588da54e838771ff0f7adc0",
+      "git-tree": "fde421a2fe6e6bf82bf31bfc0b2b1b08e2a0f2a8",
       "version": "2.0.0",
       "port-version": 0
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -29,7 +29,7 @@
       "port-version": 0
     },
     "secp256k1-internal": {
-      "baseline": "1.0.0",
+      "baseline": "0.7.0",
       "port-version": 0
     },
     "softfloat": {

--- a/versions/l-/libsodium.json
+++ b/versions/l-/libsodium.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5990c4eada93bb62c7d5f2e0c035fcab08004b9b",
+      "git-tree": "2fad4da807710810b0bf776d4dbcabe0fdb7c270",
       "version": "1.0.20-wire",
       "port-version": 0
     }

--- a/versions/s-/secp256k1-internal.json
+++ b/versions/s-/secp256k1-internal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ace62f94a220b2ee82126c7614b31ac41ad07f51",
+      "version": "0.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9cb9bc3b914701ca80ad575b401ec3b21ca73e04",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
Upgrade to 0.7.0 of secp256k1 from 0.4.0.
Remove invalid SHA512 entries for vcpkg_from_git.