### PR TITLE
Update to wire-sys-vm version 1.0.2

### DIFF
--- a/ports/wire-sys-vm/portfile.cmake
+++ b/ports/wire-sys-vm/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://github.com/Wire-Network/eos-vm
-    REF 3dc80b41b919046664d1737e6baa99c07f438013
+    REF d6500daf051093c1addb61a4d9133c397b8c357b
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS

--- a/ports/wire-sys-vm/vcpkg.json
+++ b/ports/wire-sys-vm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wire-sys-vm",
-  "version": "1.0.1-rc1",
+  "version": "1.0.2",
   "description": "Wire VM for contract execution. Originally part of eos",
   "homepage": "https://github.com/Wire-Network/wire-eos-vm",
   "supports": "x86 | x64 | arm | arm64",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -45,7 +45,7 @@
       "port-version": 0
     },
     "wire-sys-vm": {
-      "baseline": "1.0.1-rc1",
+      "baseline": "1.0.2",
       "port-version": 0
     }
   }

--- a/versions/w-/wire-sys-vm.json
+++ b/versions/w-/wire-sys-vm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b36b9ed2940b2afeae080bbf97fe14b047735c7b",
+      "version": "1.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "43d1a9f098ac1bca790eb8b731531e81ebcd7c50",
       "version": "1.0.1-rc1",
       "port-version": 0


### PR DESCRIPTION
The wire-sys-vm includes "deadlock" fix. See https://github.com/Wire-Network/eos-vm/pull/6