### PR TITLE
boringssl-custom: bump to 1.0.2, use google/boringssl upstream directly

### DIFF
--- a/ports/boringssl-custom/boringssl-customCMakeLists.txt.cmake
+++ b/ports/boringssl-custom/boringssl-customCMakeLists.txt.cmake
@@ -1,34 +1,34 @@
-include(GNUInstallDirs)
 
-add_compile_definitions(BORINGSSL_IMPLEMENTATION=1)
-add_compile_definitions(OPENSSL_EXPORT=1)
+# ----------------------------------------------------------------------------
+# Wire-network additions appended to upstream BoringSSL CMakeLists.txt.
+# See portfile.cmake for rationale.
+# ----------------------------------------------------------------------------
 
+# Upstream's -Werror is tuned for its own CI matrix and trips newer compilers.
+# Applied to every upstream-defined library target we may transitively pull in.
 target_compile_options(fipsmodule PRIVATE -Wno-error)
-target_compile_options(crypto PRIVATE -Wno-error)
-target_compile_options(decrepit PRIVATE -Wno-error)
-target_compile_options(ssl PRIVATE -Wno-error)
+target_compile_options(crypto     PRIVATE -Wno-error)
+target_compile_options(decrepit   PRIVATE -Wno-error)
+target_compile_options(ssl        PRIVATE -Wno-error)
+target_compile_options(pki        PRIVATE -Wno-error)
 
-#paranoia for when a dependent library depends on openssl (such as libcurl)
+# Hidden visibility: when a transitive dep (notably libcurl built with openssl
+# support) gets linked into the same binary, this prevents our symbols from
+# being preempted by a system libcrypto that happens to be loaded first.
 set_target_properties(fipsmodule PROPERTIES C_VISIBILITY_PRESET hidden)
-set_target_properties(crypto PROPERTIES C_VISIBILITY_PRESET hidden)
-set_target_properties(decrepit PROPERTIES C_VISIBILITY_PRESET hidden)
-set_target_properties(ssl PROPERTIES C_VISIBILITY_PRESET hidden)
+set_target_properties(crypto     PROPERTIES C_VISIBILITY_PRESET hidden)
+set_target_properties(decrepit   PROPERTIES C_VISIBILITY_PRESET hidden)
+set_target_properties(ssl        PROPERTIES C_VISIBILITY_PRESET hidden)
 
-add_library(boringssl INTERFACE)
-target_link_libraries(boringssl INTERFACE crypto decrepit ssl)
-target_include_directories(boringssl INTERFACE src/include)
-
-# avoid conflict with system lib
+# Rename the crypto archive to libbscrypto.a. Ssl is left as libssl.a; no
+# widespread system-libssl.a collision in practice, and the consumer-side
+# Config.cmake accepts either spelling.
 set_target_properties(crypto PROPERTIES PREFIX libbs)
 
-install(TARGETS crypto decrepit fipsmodule ssl
+# Decrepit is defined by upstream (add_library(decrepit ...)) but not listed
+# in upstream's install(TARGETS crypto ssl ...). Install it so find_library()
+# in boringssl-customConfig.cmake can locate libdecrepit.a.
+install(TARGETS decrepit
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-
-install(
-  DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/include/"
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-)
-
-# TODO: Generate cmake config files for boringssl

--- a/ports/boringssl-custom/boringssl-customConfig.cmake.in
+++ b/ports/boringssl-custom/boringssl-customConfig.cmake.in
@@ -62,4 +62,13 @@ if(NOT TARGET boringssl::crypto OR NOT TARGET boringssl::decrepit OR NOT TARGET 
   boringssl_set_target_libs(TARGET decrepit NAMES libdecrepit decrepit)
   boringssl_set_target_libs(TARGET ssl NAMES libbsssl libbssl libssl bsssl bssl ssl)
 
+  # Mirror upstream's target_link_libraries(decrepit ssl crypto) and
+  # target_link_libraries(ssl crypto). This propagates through cmake's topological
+  # sort so a consumer writing `target_link_libraries(x PRIVATE boringssl::ssl
+  # boringssl::crypto boringssl::decrepit)` ends up with libdecrepit ahead of
+  # libcrypto on the ld.bfd command line, satisfying static archive resolution
+  # order (decrepit/cfb/cfb.cc calls AES_set_encrypt_key which lives in crypto).
+  set_target_properties(boringssl::ssl      PROPERTIES INTERFACE_LINK_LIBRARIES "boringssl::crypto")
+  set_target_properties(boringssl::decrepit PROPERTIES INTERFACE_LINK_LIBRARIES "boringssl::ssl;boringssl::crypto")
+
 endif()

--- a/ports/boringssl-custom/portfile.cmake
+++ b/ports/boringssl-custom/portfile.cmake
@@ -1,68 +1,62 @@
-set(BORINGSSL_GIT_URL "https://github.com/Wire-Network/boringssl-custom.git")
-set(BORINGSSL_COMMIT 15500a39d874c39aa8e8adf7367a9c6a52753b60)
+# Wire-network custom BoringSSL port.
+#
+# Pinned to an upstream release (google/boringssl, live-at-head model) and
+# patched minimally via a cmake-append, not via generate_build_files.py:
+#
+#   * The `decrepit` target (RIPEMD160, CAST, BLOWFISH) is built by upstream
+#     but not installed; we install it because RIPEMD160 is consensus-critical
+#     in wire-sysio (fc::crypto::ripemd160).
+#   * The crypto target is renamed to libbscrypto.a to avoid filename collision
+#     with system libcrypto when other deps (libcurl) link OpenSSL.
+#   * Hidden visibility on crypto/ssl/decrepit/fipsmodule keeps symbols out of
+#     transitive deps that may dlopen system openssl.
+#   * -Werror is silenced; upstream's warnings track bleeding-edge compilers.
+#   * Upstream's latent `OpenSSL` cmake package export is removed so consumers
+#     go through boringssl-customConfig.cmake, never find_package(OpenSSL).
+#
+# Historical note: earlier versions of this port cloned AntelopeIO/boringssl
+# at commit 15500a39d8 and invoked util/generate_build_files.py (requiring Go
+# + Python at build time). Upstream boringssl's own cmake dropped the Go
+# requirement for non-FIPS / non-prefix builds, so we consume it directly.
 
-# FIND GIT EXECUTABLE
-find_program(GIT git REQUIRED)
-find_program(GO go REQUIRED)
-find_program(PY3 python3 REQUIRED)
-
-# SETUP CLONE DIRECTORY
-set(BORINGSSL_CLONE_DIR "${DOWNLOADS}/boringssl-src-${BORINGSSL_COMMIT}")
-
-# CHECK IF CLONE ALREADY EXISTS, OTHERWISE CLONE IT
-if(NOT EXISTS "${BORINGSSL_CLONE_DIR}/.fetched")
-  message(STATUS "[boringssl] Cloning super-project (with submodules) @ ${BORINGSSL_COMMIT}")
-  file(REMOVE_RECURSE "${BORINGSSL_CLONE_DIR}")
-  vcpkg_execute_required_process(
-    ALLOW_IN_DOWNLOAD_MODE
-    COMMAND "${GIT}" clone --recurse-submodules --progress "${BORINGSSL_GIT_URL}" "${BORINGSSL_CLONE_DIR}"
-    WORKING_DIRECTORY "${DOWNLOADS}"
-    LOGNAME boringssl-git-clone
-  )
-  vcpkg_execute_required_process(
-    ALLOW_IN_DOWNLOAD_MODE
-    COMMAND "${GIT}" checkout ${BORINGSSL_COMMIT}
-    WORKING_DIRECTORY "${BORINGSSL_CLONE_DIR}"
-    LOGNAME boringssl-git-checkout
-  )
-  vcpkg_execute_required_process(
-    ALLOW_IN_DOWNLOAD_MODE
-    COMMAND "${GIT}" submodule update --init --recursive --jobs ${VCPKG_CONCURRENCY}
-    WORKING_DIRECTORY "${BORINGSSL_CLONE_DIR}"
-    LOGNAME boringssl-git-submodule-update
-  )
-  file(WRITE "${BORINGSSL_CLONE_DIR}/.fetched" "commit=${BORINGSSL_COMMIT}\n")
-else()
-  message(STATUS "[boringssl] Using cached clone in ${BORINGSSL_CLONE_DIR}")
-endif()
-
-# COPY TO BUILDTREES WORKING SOURCE DIRECTORY
-set(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src/boringssl-${BORINGSSL_COMMIT}")
-if(EXISTS "${SOURCE_PATH}")
-  file(REMOVE_RECURSE "${SOURCE_PATH}")
-endif()
-file(MAKE_DIRECTORY "${SOURCE_PATH}/src")
-file(COPY "${BORINGSSL_CLONE_DIR}/" DESTINATION "${SOURCE_PATH}/src/")
-
-vcpkg_execute_required_process(
-  COMMAND ${PY3} ./src/util/generate_build_files.py cmake
-  WORKING_DIRECTORY ${SOURCE_PATH}
-  LOGNAME boringssl-custom-generate-build-files
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO google/boringssl
+  REF 0.20260413.0
+  SHA512 9ad7cc1e31d878fd466ed66e54311a1e1a0777c4766fa8ff9aa824f0522b091d4416c1caaa9f081f602004614191d4f77b4692ee0d04114457998d116d07a6ac
+  HEAD_REF main
 )
 
+# Append wire-specific target tweaks after upstream's CMakeLists.txt content.
 file(READ "${CMAKE_CURRENT_LIST_DIR}/boringssl-customCMakeLists.txt.cmake" BORINGSSL_CUSTOM_CMAKELISTS_TXT)
 file(APPEND "${SOURCE_PATH}/CMakeLists.txt" "${BORINGSSL_CUSTOM_CMAKELISTS_TXT}")
 
-# NOW CONFIGURE AND INSTALL USING CMAKE
 vcpkg_cmake_configure(
-  SOURCE_PATH ${SOURCE_PATH}
+  SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS
-  -DOPENSSL_EXPORT=1
-  -DBORINGSSL_IMPLEMENTATION=1
+    -DBUILD_TESTING=OFF
 )
 
-# INSTALL
 vcpkg_cmake_install()
+
+# Strip artifacts wire-sysio does not consume, keeping the package lean and
+# satisfying vcpkg post-build policy (no latent OpenSSL package, no duplicate
+# debug headers, no empty dirs):
+#   * lib/cmake/OpenSSL       - upstream's OpenSSL cmake package; wire-sysio
+#                                deliberately avoids find_package(OpenSSL)
+#                                (leap commit e2be85a296). boringssl-custom
+#                                is the supported entry point.
+#   * debug/include           - upstream duplicates headers to debug; vcpkg
+#                                wants headers once, under include/.
+#   * bin/bssl, tools/        - CLI swiss-army tool not consumed by wire-sysio.
+file(REMOVE_RECURSE
+  "${CURRENT_PACKAGES_DIR}/lib/cmake"
+  "${CURRENT_PACKAGES_DIR}/debug/lib/cmake"
+  "${CURRENT_PACKAGES_DIR}/debug/include"
+  "${CURRENT_PACKAGES_DIR}/bin"
+  "${CURRENT_PACKAGES_DIR}/debug/bin"
+  "${CURRENT_PACKAGES_DIR}/tools"
+)
 
 configure_file(
   "${CMAKE_CURRENT_LIST_DIR}/boringssl-customConfig.cmake.in"
@@ -70,20 +64,5 @@ configure_file(
   @ONLY
 )
 
-# CMAKE CONFIG FIXUP FOR ``boringssl-custom``
-#if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/boringssl-custom")
-#  vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/boringssl-custom)
-#elseif(EXISTS "${CURRENT_PACKAGES_DIR}/share/boringssl-custom")
-#  vcpkg_cmake_config_fixup(CONFIG_PATH share/boringssl-custom)
-#else()
-#  message(NOTICE "[boringssl] Could not find expected CMake config path for fixup; package config files may be missing.")
-#endif()
-
-## COPY LICENSE
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/src/LICENSE")
-
-# COPY PDB FILES
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 vcpkg_copy_pdbs()
-
-#file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
-

--- a/ports/boringssl-custom/vcpkg.json
+++ b/ports/boringssl-custom/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boringssl-custom",
-  "version": "1.0.1",
-  "description": "Custom BoringSSL port for wire.network. Derived from the LEAP build process",
+  "version": "1.0.2",
+  "description": "Custom BoringSSL port for wire.network; pinned upstream with decrepit installed and libbs prefix on crypto.",
   "homepage": "https://wire.network/",
   "supports": "!uwp",
   "dependencies": [

--- a/versions/b-/boringssl-custom.json
+++ b/versions/b-/boringssl-custom.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "262e88b4eca7b56a993a9978a46ce740270b97f7",
+      "git-tree": "c882d067e0b92ce592c02f81a2fc56170e268ef9",
       "version": "1.0.2",
       "port-version": 0
     },

--- a/versions/b-/boringssl-custom.json
+++ b/versions/b-/boringssl-custom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "262e88b4eca7b56a993a9978a46ce740270b97f7",
+      "version": "1.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c5d3529dc0a702db528e5ba65786e94b8c78fe2d",
       "version": "1.0.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -13,7 +13,7 @@
       "port-version": 1
     },
     "boringssl-custom": {
-      "baseline": "1.0.1",
+      "baseline": "1.0.2",
       "port-version": 0
     },
     "catch2": {


### PR DESCRIPTION
Bumps the `boringssl-custom` port from 1.0.1 to 1.0.2 and rewrites its build recipe around upstream google/boringssl 0.20260413.0 (released 2026-04-14).

## What changes

- Source: `Wire-Network/boringssl-custom @ 15500a39d8` (fork of AntelopeIO/boringssl at a Sep 2023 pin) -> `google/boringssl @ 0.20260413.0`.
- Delivery: `git clone --recurse-submodules` + `util/generate_build_files.py cmake` -> `vcpkg_from_github` with the release tarball.
- Build-host deps: **`go`, `python3`, `git` no longer required**. Upstream's own cmake handles all codegen; Go is only needed for BORINGSSL_PREFIX / FIPS / test builds, none of which we enable.
- `Wire-Network/boringssl-custom` fork can be archived once this lands. Its only delta was `generate_build_files.py` emitting a `libdecrepit` cmake target; we now install decrepit directly.

## Wire-specific tweaks preserved

- `decrepit` archive installed (RIPEMD160 is consensus-critical in `fc::crypto::ripemd160`; upstream builds the target but omits it from `install(TARGETS ...)`).
- `crypto` archive renamed to `libbscrypto.a` to avoid collision with system `libcrypto.a` when transitive deps (libcurl with openssl feature) get linked in.
- Hidden symbol visibility on `crypto`/`ssl`/`decrepit`/`fipsmodule`.
- `-Wno-error` applied to the upstream library targets (new `pki` target added vs. the old pin).

## Hygiene

- Upstream's `install(FILES cmake/OpenSSLConfig.cmake ...)` output (`lib/cmake/OpenSSL/`) is removed post-install -- wire-sysio deliberately does not `find_package(OpenSSL)` (leap commit `e2be85a296`). Consumers use `find_package(boringssl-custom CONFIG REQUIRED)` and link `boringssl::crypto|ssl|decrepit`; no consumer-side changes needed.
- Duplicate debug headers, `bssl` CLI, and empty dirs removed to pass vcpkg post-build policy checks. Confirmed clean locally (0 post-build check problems).

## Consumer impact

None. Port keeps its name `boringssl-custom`, exports the same three cmake targets (`boringssl::crypto`, `boringssl::ssl`, `boringssl::decrepit`), same library names under `lib/`. Companion PR in `wire-sysio` does the baseline + override bump.