### PR TITLE
boringssl-custom: install libssl.pc and libcrypto.pc, bump to 1.0.3

### DIFF
--- a/ports/boringssl-custom/libcrypto.pc.in
+++ b/ports/boringssl-custom/libcrypto.pc.in
@@ -1,0 +1,10 @@
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libcrypto
+Description: BoringSSL crypto library (wire-network custom port; archive name: libbscrypto.a)
+Version: @VERSION@
+Libs: -L${libdir} -lbscrypto
+Cflags: -I${includedir}

--- a/ports/boringssl-custom/libssl.pc.in
+++ b/ports/boringssl-custom/libssl.pc.in
@@ -1,0 +1,11 @@
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libssl
+Description: BoringSSL TLS library (wire-network custom port)
+Version: @VERSION@
+Requires.private: libcrypto
+Libs: -L${libdir} -lssl
+Cflags: -I${includedir}

--- a/ports/boringssl-custom/portfile.cmake
+++ b/ports/boringssl-custom/portfile.cmake
@@ -64,5 +64,38 @@ configure_file(
   @ONLY
 )
 
+# Install pkg-config metadata for libssl and libcrypto. Required so consumers
+# (notably the vcpkg curl port's dependencies.patch, which calls
+# `pkg_check_modules(REQUIRED libssl)` / `pkg_check_modules(REQUIRED libcrypto)`)
+# resolve to our boringssl-custom static archives instead of falling back to a
+# system openssl install (libssl-dev on Ubuntu). The crypto archive is renamed
+# libbscrypto.a (see boringssl-customCMakeLists.txt.cmake), so libcrypto.pc
+# emits `-lbscrypto`. ${pcfiledir} keeps the .pc files relocatable across the
+# vcpkg install / consumer trees.
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+configure_file(
+  "${CMAKE_CURRENT_LIST_DIR}/libssl.pc.in"
+  "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libssl.pc"
+  @ONLY
+)
+configure_file(
+  "${CMAKE_CURRENT_LIST_DIR}/libcrypto.pc.in"
+  "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libcrypto.pc"
+  @ONLY
+)
+if(NOT DEFINED VCPKG_BUILD_TYPE)
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+  configure_file(
+    "${CMAKE_CURRENT_LIST_DIR}/libssl.pc.in"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libssl.pc"
+    @ONLY
+  )
+  configure_file(
+    "${CMAKE_CURRENT_LIST_DIR}/libcrypto.pc.in"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libcrypto.pc"
+    @ONLY
+  )
+endif()
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 vcpkg_copy_pdbs()

--- a/ports/boringssl-custom/vcpkg.json
+++ b/ports/boringssl-custom/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boringssl-custom",
-  "version": "1.0.2",
-  "description": "Custom BoringSSL port for wire.network; pinned upstream with decrepit installed and libbs prefix on crypto.",
+  "version": "1.0.3",
+  "description": "Custom BoringSSL port for wire.network; pinned upstream with decrepit installed and libbs prefix on crypto. Installs libssl.pc/libcrypto.pc so consumers do not fall back to system libssl-dev for pkg-config.",
   "homepage": "https://wire.network/",
   "supports": "!uwp",
   "dependencies": [

--- a/versions/b-/boringssl-custom.json
+++ b/versions/b-/boringssl-custom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ef0bf385f395dfa3705ac483945656afd200d38",
+      "version": "1.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "c882d067e0b92ce592c02f81a2fc56170e268ef9",
       "version": "1.0.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -13,7 +13,7 @@
       "port-version": 1
     },
     "boringssl-custom": {
-      "baseline": "1.0.2",
+      "baseline": "1.0.3",
       "port-version": 0
     },
     "catch2": {


### PR DESCRIPTION
Adds pkg-config metadata so consumers (notably the curl port's `dependencies.patch` which calls `pkg_check_modules(REQUIRED libssl)` / `(REQUIRED libcrypto)`) resolve to our boringssl-custom static archives instead of falling back to system libssl-dev. `libcrypto.pc` emits `-lbscrypto` to match the renamed archive from `boringssl-customCMakeLists.txt.cmake`. `.pc` files use a relocatable `${pcfiledir}/../..` prefix.

Verified end-to-end against a fresh wire-sysio build: boringssl-custom 1.0.3 + curl 8.16.0 builds without libssl-dev on the host, and a statically linked smoke client successfully completes a TLS handshake against https://example.com with `ssl_version: BoringSSL` (not system openssl).