### PR TITLE
Update wire-sys-vm upstream pin

### DIFF
--- a/ports/wire-sys-vm/portfile.cmake
+++ b/ports/wire-sys-vm/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://github.com/Wire-Network/eos-vm
-    REF a89d24a3cd4a2fc634ac81c5edfdc88c0bf283e3
+    REF 31ad8527c0d9f124e7606d0899ab0477c9965551
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS
@@ -24,5 +24,14 @@ vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
+file(GLOB_RECURSE debug_contents "${CURRENT_PACKAGES_DIR}/debug/*")
+if(NOT debug_contents)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/wire-sys-vm/vcpkg.json
+++ b/ports/wire-sys-vm/vcpkg.json
@@ -1,32 +1,14 @@
 {
   "name": "wire-sys-vm",
   "version": "1.1.1",
+  "port-version": 1,
   "description": "Wire VM for contract execution. Originally part of eos",
   "homepage": "https://github.com/Wire-Network/eos-vm",
   "supports": "x86 | x64 | arm | arm64",
   "dependencies": [
-    {
-      "name": "catch2",
-      "features": [
-        "no-posix-signals"
-      ]
-    },
-    {
-      "name": "llvm",
-      "default-features": false,
-      "features": [
-        "enable-rtti",
-        "target-aarch64",
-        "target-x86"
-      ]
-    },
     "softfloat",
     {
       "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
       "host": true
     }
   ],

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -58,7 +58,7 @@
     },
     "wire-sys-vm": {
       "baseline": "1.1.1",
-      "port-version": 0
+      "port-version": 1
     }
   }
 }

--- a/versions/w-/wire-sys-vm.json
+++ b/versions/w-/wire-sys-vm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04a9ce438f66c4b0b185bbaee05a62fa63aa28e9",
+      "version": "1.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "6ed9f5dce902d45f3e6e8735dbba21a877bc0e76",
       "version": "1.1.1",
       "port-version": 0


### PR DESCRIPTION
## Summary
- update wire-sys-vm to Wire-Network/eos-vm commit 31ad8527c0d9f124e7606d0899ab0477c9965551
- simplify wire-sys-vm dependencies to match upstream's current vcpkg manifest
- bump port-version to 1 and refresh registry version metadata
- clean duplicated debug include/share artifacts emitted by the upstream install
- install copyright via vcpkg_install_copyright

## Verification
- Created a local manifest client at /tmp/wire-sys-vm-vcpkg-client using this registry branch.
- Ran: /home/ssm-user/experiments/eos-vm/vcpkg/vcpkg install --x-manifest-root=/tmp/wire-sys-vm-vcpkg-client --binarysource=clear
- Result: wire-sys-vm[core,softfloat-skip-install]:x64-linux@1.1.1#1 built successfully and passed post-build validation cleanly.