### PR TITLE
macOS arm64 overlay fixes

### DIFF
--- a/ports/boost/post-install-cmake-config.sh
+++ b/ports/boost/post-install-cmake-config.sh
@@ -26,16 +26,19 @@ for libDir in "${cmakeLibDir}" "${cmakeDebugLibDir}"; do
     pushd "${libDir}"
 
     # Remove numeric_ublas references from accumulators config
-    cd "boost_accumulators-${ver}"
-    sed -i '/find_dependency(boost_numeric_ublas .* EXACT)/d' boost_accumulators-config.cmake
-    cd "${libDir}"
+    accumulatorsConfigDir="boost_accumulators-${ver}"
+    if [ -d "${accumulatorsConfigDir}" ]; then
+        cd "${accumulatorsConfigDir}"
+        perl -0pi -e 's/^.*find_dependency\(boost_numeric_ublas .* EXACT\).*\n//mg' boost_accumulators-config.cmake
+        cd "${libDir}"
+    fi
 
     # Fix iostreams: replace zstd::libzstd_shared with zstd::libzstd_static
     # Boost 1.89.0 CMake build incorrectly hardcodes the shared zstd target,
     # but we build with VCPKG_LIBRARY_LINKAGE=static so only the static target exists
     iostreamsTargetsDir="boost_iostreams-${ver}-static"
     if [ -d "${iostreamsTargetsDir}" ]; then
-        sed -i 's/zstd::libzstd_shared/zstd::libzstd_static/g' "${iostreamsTargetsDir}/boost_iostreams-targets.cmake"
+        perl -pi -e 's/zstd::libzstd_shared/zstd::libzstd_static/g' "${iostreamsTargetsDir}/boost_iostreams-targets.cmake"
         echo "Fixed zstd target reference in ${iostreamsTargetsDir}/boost_iostreams-targets.cmake"
     fi
 
@@ -45,11 +48,10 @@ for libDir in "${cmakeLibDir}" "${cmakeDebugLibDir}"; do
     # own static libatomic.a via LIBATOMIC_STATIC, so the bare name just
     # causes an unwanted NEEDED entry for libatomic.so at runtime.
     grep -rl ';atomic"' . 2>/dev/null | while read -r f; do
-        sed -i 's/;atomic"/"/g' "$f"
+        perl -pi -e 's/;atomic"/"/g' "$f"
         echo "Removed bare atomic link dep from $f"
     done
 
     popd
 
 done
-

--- a/ports/boost/vcpkg.json
+++ b/ports/boost/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost",
   "version": "1.89.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Peer-reviewed portable C++ source libraries",
   "homepage": "https://github.com/boostorg/boost",
   "supports": "!uwp",

--- a/ports/secp256k1-internal/CMakeLists.txt
+++ b/ports/secp256k1-internal/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.15)
+
 project(secp256k1-internal)
 
 include(GNUInstallDirs)

--- a/ports/secp256k1-internal/portfile.cmake
+++ b/ports/secp256k1-internal/portfile.cmake
@@ -15,6 +15,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
 vcpkg_cmake_config_fixup(CONFIG_PATH "share/${PORT}" PACKAGE_NAME ${PORT})
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/secp256k1-internal/vcpkg.json
+++ b/ports/secp256k1-internal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "secp256k1-internal",
   "version": "0.7.0",
+  "port-version": 1,
   "description": "Optimized C library for EC operations on curve",
   "homepage": "https://github.com/bitcoin-core/secp256k1",
   "license": "MIT",

--- a/ports/softfloat/portfile.cmake
+++ b/ports/softfloat/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://github.com/Wire-Network/berkeley-softfloat-3
-    REF 31f071938137b44d794665552d5b0092c1e10306
+    REF 57c9d941d796d283691e1d0e12faee28bebe226e
 )
 
 vcpkg_cmake_configure(
@@ -20,4 +20,3 @@ vcpkg_cmake_config_fixup(CONFIG_PATH "share/${PORT}" PACKAGE_NAME ${PORT})
 vcpkg_copy_pdbs()
 
 file(INSTALL "${SOURCE_PATH}/COPYING.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-

--- a/ports/softfloat/vcpkg.json
+++ b/ports/softfloat/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "softfloat",
   "version": "3.0.0",
+  "port-version": 1,
   "description": "Berkeley SoftFloat 3 - Software IEC/IEEE Floating-Point Arithmetic Package",
   "homepage": "https://github.com/Wire-Network/berkeley-softfloat-3",
   "supports": "x86 | x64 | arm | arm64 | wasm32",

--- a/ports/wire-sys-vm/portfile.cmake
+++ b/ports/wire-sys-vm/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://github.com/Wire-Network/eos-vm
-    REF 31ad8527c0d9f124e7606d0899ab0477c9965551
+    REF 09cf11c77f7869f6192cff14006435681ec94c3d
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS

--- a/ports/wire-sys-vm/portfile.cmake
+++ b/ports/wire-sys-vm/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://github.com/Wire-Network/eos-vm
-    REF 09cf11c77f7869f6192cff14006435681ec94c3d
+    REF 72a9985a744fdb82e304ffb8bd4b1b7ba6c4610e
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS

--- a/ports/wire-sys-vm/vcpkg.json
+++ b/ports/wire-sys-vm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wire-sys-vm",
   "version": "1.1.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Wire VM for contract execution. Originally part of eos",
   "homepage": "https://github.com/Wire-Network/eos-vm",
   "supports": "x86 | x64 | arm | arm64",

--- a/ports/wire-sys-vm/vcpkg.json
+++ b/ports/wire-sys-vm/vcpkg.json
@@ -1,10 +1,13 @@
 {
   "name": "wire-sys-vm",
   "version": "1.1.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Wire VM for contract execution. Originally part of eos",
   "homepage": "https://github.com/Wire-Network/eos-vm",
   "supports": "x86 | x64 | arm | arm64",
+  "default-features": [
+    "softfloat-skip-install"
+  ],
   "dependencies": [
     "softfloat",
     {

--- a/versions/b-/boost.json
+++ b/versions/b-/boost.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "abbe59817c27da60746dc32a6b37c06c8e70c3d0",
+      "version": "1.89.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "f4e0fbaf7036304c6c6faa7605b66bef3b2c6468",
       "version": "1.89.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -58,7 +58,7 @@
     },
     "wire-sys-vm": {
       "baseline": "1.1.1",
-      "port-version": 2
+      "port-version": 3
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -58,7 +58,7 @@
     },
     "wire-sys-vm": {
       "baseline": "1.1.1",
-      "port-version": 1
+      "port-version": 2
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
     },
     "boost": {
       "baseline": "1.89.0",
-      "port-version": 1
+      "port-version": 2
     },
     "boringssl-custom": {
       "baseline": "1.0.3",
@@ -50,11 +50,11 @@
     },
     "secp256k1-internal": {
       "baseline": "0.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "softfloat": {
       "baseline": "3.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "wire-sys-vm": {
       "baseline": "1.1.1",

--- a/versions/s-/secp256k1-internal.json
+++ b/versions/s-/secp256k1-internal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "da1386fe4148836f6a5e68199dae5234f6255614",
+      "version": "0.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ace62f94a220b2ee82126c7614b31ac41ad07f51",
       "version": "0.7.0",
       "port-version": 0

--- a/versions/s-/softfloat.json
+++ b/versions/s-/softfloat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2b937b0edae68db2b582f00974c004f324f5492a",
+      "version": "3.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b69e877ce88bf433730f1cec789774b51a57696c",
       "version": "3.0.0",
       "port-version": 0

--- a/versions/w-/wire-sys-vm.json
+++ b/versions/w-/wire-sys-vm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e87002728f25e2a0c392230c06946771b0aeded",
+      "version": "1.1.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "6e3df1250c513a2906691ca68f973467f1608ad3",
       "version": "1.1.1",
       "port-version": 2

--- a/versions/w-/wire-sys-vm.json
+++ b/versions/w-/wire-sys-vm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e3df1250c513a2906691ca68f973467f1608ad3",
+      "version": "1.1.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "04a9ce438f66c4b0b185bbaee05a62fa63aa28e9",
       "version": "1.1.1",
       "port-version": 1


### PR DESCRIPTION
## Summary

Move the local macOS arm64 overlay fixes for SoftFloat, secp256k1-internal, Boost, and the merged eos-vm SoftFloat type rename follow-up into the Wire vcpkg registry.

## What changed

- Updated `softfloat` to the merged SoftFloat commit containing Apple arm64 and CMake package export fixes.
- Added `cmake_minimum_required(VERSION 3.15)` to `secp256k1-internal` and removed duplicated debug headers after install.
- Made Boost's post-install CMake metadata cleanup portable across GNU and BSD userlands by replacing `sed -i` with `perl` and guarding optional config directories. macOS ships BSD `sed`, where in-place editing requires an explicit backup suffix argument such as `-i ""`; GNU `sed` accepts bare `-i`. Using bare `sed -i` therefore treats the next token differently on macOS and can fail before patching the generated CMake config files.
- Updated `wire-sys-vm` to the merged Wire-Network/eos-vm#11 commit (`72a9985`) and bumped it to `1.1.1#3`.
- Enabled `wire-sys-vm`'s existing `softfloat-skip-install` feature by default so the port consumes the `softfloat` dependency without installing duplicate SoftFloat files.
- Bumped port versions and regenerated registry version metadata.

## Why

These changes let `wire-sysio` consume the registry directly instead of carrying local overlay ports for Apple Silicon builds, while matching eos-vm's renamed SoftFloat carrier types.

## Testing

- `vcpkg install softfloat:arm64-osx` from a temporary install/build root.
- `vcpkg install softfloat:arm64-osx secp256k1-internal:arm64-osx` from a temporary install/build root during implementation.
- `vcpkg install wire-sys-vm:arm64-osx --overlay-ports=$PWD/ports` from a temporary install/build root against eos-vm merge commit `72a9985`.
- Boost post-install script smoke test against synthetic generated CMake config files.
- `bash -n ports/boost/post-install-cmake-config.sh`.
- `jq empty` on changed manifests and version metadata.
- `git diff --check`.
