### PR TITLE
Update wire-sys-vm to eos-vm master

### DIFF
--- a/ports/wire-sys-vm/portfile.cmake
+++ b/ports/wire-sys-vm/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://github.com/Wire-Network/eos-vm
-    REF 72a9985a744fdb82e304ffb8bd4b1b7ba6c4610e
+    REF 54e3d02eb9d7a4bb4bf41a9e3d5adc925a09c6b0
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS

--- a/ports/wire-sys-vm/vcpkg.json
+++ b/ports/wire-sys-vm/vcpkg.json
@@ -1,19 +1,19 @@
 {
   "name": "wire-sys-vm",
-  "version": "1.1.1",
-  "port-version": 3,
+  "version": "1.2.0",
+  "port-version": 0,
   "description": "Wire VM for contract execution. Originally part of eos",
   "homepage": "https://github.com/Wire-Network/eos-vm",
   "supports": "x86 | x64 | arm | arm64",
-  "default-features": [
-    "softfloat-skip-install"
-  ],
   "dependencies": [
     "softfloat",
     {
       "name": "vcpkg-cmake",
       "host": true
     }
+  ],
+  "default-features": [
+    "softfloat-skip-install"
   ],
   "features": {
     "softfloat-skip-install": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -57,8 +57,8 @@
       "port-version": 1
     },
     "wire-sys-vm": {
-      "baseline": "1.1.1",
-      "port-version": 3
+      "baseline": "1.2.0",
+      "port-version": 0
     }
   }
 }

--- a/versions/w-/wire-sys-vm.json
+++ b/versions/w-/wire-sys-vm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a2d6d75196c63798a907998678b570f17c55ac9",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0e87002728f25e2a0c392230c06946771b0aeded",
       "version": "1.1.1",
       "port-version": 3


### PR DESCRIPTION
## Summary

Updates the `wire-sys-vm` registry entry for version `1.2.0` to point at the current `eos-vm` master commit, which includes macOS arm64 JIT support.

## What changed

- Pointed `ports/wire-sys-vm/portfile.cmake` at `54e3d02eb9d7a4bb4bf41a9e3d5adc925a09c6b0`.
- Set `wire-sys-vm` `1.2.0` to `port-version: 0`.
- Updated the baseline and version database metadata for `wire-sys-vm`.
- Kept the pre-`1.2.0` `wire-sys-vm` version history intact.

## Why

This picks up the upstream `eos-vm` changes needed for macOS arm64 JIT support while retaining older `wire-sys-vm` versions in the registry.
