### PR TITLE
Fix Boost downloads directory for cold source builds

### DIFF
--- a/ports/boost/portfile.cmake
+++ b/ports/boost/portfile.cmake
@@ -10,6 +10,7 @@ cmake_policy(SET CMP0116 OLD) #suppress warning about Boost::xxxx targets not be
 find_program(GIT git REQUIRED)
 
 # SETUP CLONE DIRECTORY
+file(MAKE_DIRECTORY "${DOWNLOADS}")
 set(BOOST_CLONE_DIR "${DOWNLOADS}/boost-src-${BOOST_COMMIT}")
 
 # CHECK IF CLONE ALREADY EXISTS, OTHERWISE CLONE IT

--- a/ports/boost/vcpkg.json
+++ b/ports/boost/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost",
   "version": "1.89.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Peer-reviewed portable C++ source libraries",
   "homepage": "https://github.com/boostorg/boost",
   "supports": "!uwp",

--- a/versions/b-/boost.json
+++ b/versions/b-/boost.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc8f48c58f04daa22d3e88e8b089e6dbc964faba",
+      "version": "1.89.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "abbe59817c27da60746dc32a6b37c06c8e70c3d0",
       "version": "1.89.0",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
     },
     "boost": {
       "baseline": "1.89.0",
-      "port-version": 2
+      "port-version": 3
     },
     "boringssl-custom": {
       "baseline": "1.0.3",


### PR DESCRIPTION
## Summary

- Create the vcpkg downloads directory before the custom Boost port runs its manual `git clone`.
- Bump Boost from `1.89.0#2` to `1.89.0#3` so the fixed recipe has distinct registry metadata and cache artifacts.
- Update the Boost version database and baseline entry for the new port revision.

## Why this is required for macOS support

The `wire-sysio` `feature/macos-arm64-support` branch updates this registry to the macOS arm64 overlay fixes from `62fce236...`. That moves Boost from `1.89.0#1` to `1.89.0#2`, where the post-install cleanup script was made portable for macOS/BSD tooling by replacing GNU `sed -i` assumptions with Perl-based edits and making optional Boost config cleanup tolerant of missing directories.

That registry bump is necessary for macOS support, but it also changes the Boost port identity. Existing CI caches may have `1.89.0#1`, while fresh macOS validation and Linux platform validation of the macOS branch need to build or restore `1.89.0#2` or later.

A cold build exposed that the custom Boost port uses `${DOWNLOADS}` as the `WORKING_DIRECTORY` for the manual Boost super-project clone without ensuring the directory exists first. The platform E2E run failed before testing could start:

```text
boost:x64-linux@1.89.0#2
Command failed: /usr/bin/git clone --recurse-submodules --progress https://github.com/boostorg/boost.git .../wire-sysio/vcpkg/downloads/boost-src-...
Working Directory: .../wire-sysio/vcpkg/downloads
Error code: no such file or directory
```

Creating `${DOWNLOADS}` makes the custom Boost overlay robust when the binary cache does not already contain the new Boost port revision. This is important for macOS support because the macOS branch intentionally introduces a new Boost port revision and should not depend on a pre-warmed cache to configure successfully.

## Validation

- Parsed updated JSON files with Python `json` module:
  - `ports/boost/vcpkg.json`
  - `versions/b-/boost.json`
  - `versions/baseline.json`
- `git diff --check`
- Verified the `versions/b-/boost.json` `git-tree` entry matches the staged `ports/boost` tree hash: `dc8f48c58f04daa22d3e88e8b089e6dbc964faba`
